### PR TITLE
feat: bundle CLIProxyAPI as optional service with auto-wire for OpenCode + Hermes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,12 @@ ANTHROPIC_API_KEY=
 # ENABLE_HERMES=true               # Start Hermes API server on HERMES_PORT
 # HERMES_PORT=8642
 
+# === CLI Proxy API (route OpenCode + Hermes through subscription accounts) ===
+# ENABLE_CLI_PROXY=true
+# CLI_PROXY_API_KEY=holycode-local
+# CLI_PROXY_AUTOWIRE=all                  # all | comma-list (opencode-anthropic, opencode-openai, opencode-google, hermes) | false
+# CLI_PROXY_HERMES_PROVIDER=anthropic     # protocol Hermes uses to talk to the proxy
+
 # === OpenCode Behavior ===
 # OPENCODE_MODEL=claude-sonnet-4-6
 # OPENCODE_PERMISSION=auto

--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,10 @@ ANTHROPIC_API_KEY=
 
 # === CLI Proxy API (route OpenCode + Hermes through subscription accounts) ===
 # ENABLE_CLI_PROXY=true
+# SECURITY: the default key "holycode-local" is published in the repo. Change
+# this to a private value before exposing port 8317 outside your own machine.
+# Note: changing this AFTER first boot does not retroactively rewrite
+# ~/.cli-proxy-api/config.yaml -- edit api-keys: there manually if you change.
 # CLI_PROXY_API_KEY=holycode-local
 # CLI_PROXY_AUTOWIRE=all                  # all | comma-list (opencode-anthropic, opencode-openai, opencode-google, hermes) | false
 # CLI_PROXY_HERMES_PROVIDER=anthropic     # protocol Hermes uses to talk to the proxy

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,10 @@
 # https://github.com/coderluii/holycode
 # ==============================================================================
 
+# CLIProxyAPI binary is extracted from the official upstream image.
+# Pinned for reproducible builds — bump together with HolyCode releases.
+FROM eceasy/cli-proxy-api:v6.10.1 AS cliproxy
+
 FROM node:22-bookworm-slim
 
 LABEL org.opencontainers.image.source=https://github.com/CoderLuii/HolyCode
@@ -165,7 +169,13 @@ COPY scripts/entrypoint.sh /usr/local/bin/entrypoint.sh
 COPY scripts/bootstrap.sh /usr/local/bin/bootstrap.sh
 COPY config/opencode.json /usr/local/share/holycode/opencode.json
 COPY config/skills /usr/local/share/holycode/skills
+COPY config/cli-proxy-api/config.example.yaml /usr/local/share/holycode/cli-proxy-api/config.example.yaml
+COPY config/hermes/config.example.yaml /usr/local/share/holycode/hermes/config.example.yaml
 RUN chmod +x /usr/local/bin/entrypoint.sh /usr/local/bin/bootstrap.sh
+
+# ---------- CLIProxyAPI binary ----------
+COPY --from=cliproxy /CLIProxyAPI/CLIProxyAPI /usr/local/bin/cli-proxy-api
+RUN chmod +x /usr/local/bin/cli-proxy-api
 
 # ---------- s6-overlay service: opencode web ----------
 COPY s6-overlay/s6-rc.d/opencode/type /etc/s6-overlay/s6-rc.d/opencode/type
@@ -183,7 +193,11 @@ COPY s6-overlay/s6-rc.d/hermes/type /etc/s6-overlay/s6-rc.d/hermes/type
 COPY s6-overlay/s6-rc.d/hermes/run /etc/s6-overlay/s6-rc.d/hermes/run
 COPY s6-overlay/s6-rc.d/paperclip/type /etc/s6-overlay/s6-rc.d/paperclip/type
 COPY s6-overlay/s6-rc.d/paperclip/run /etc/s6-overlay/s6-rc.d/paperclip/run
-RUN chmod +x /etc/s6-overlay/s6-rc.d/hermes/run /etc/s6-overlay/s6-rc.d/paperclip/run
+COPY s6-overlay/s6-rc.d/cli-proxy-api/type /etc/s6-overlay/s6-rc.d/cli-proxy-api/type
+COPY s6-overlay/s6-rc.d/cli-proxy-api/run /etc/s6-overlay/s6-rc.d/cli-proxy-api/run
+RUN chmod +x /etc/s6-overlay/s6-rc.d/hermes/run \
+    /etc/s6-overlay/s6-rc.d/paperclip/run \
+    /etc/s6-overlay/s6-rc.d/cli-proxy-api/run
 
 # ---------- Working directory ----------
 WORKDIR /workspace

--- a/README.md
+++ b/README.md
@@ -378,6 +378,10 @@ services:
 | `PAPERCLIP_DEPLOYMENT_MODE` | `authenticated` | Docker-safe Paperclip startup mode; HolyCode defaults this away from `local_trusted` |
 | `ENABLE_HERMES` | (none) | Set to `true` to start Hermes as a bundled meta-agent API |
 | `HERMES_PORT` | `8642` | Override the container port used by Hermes |
+| `ENABLE_CLI_PROXY` | (none) | Set to `true` to start the CLI Proxy API (port `8317`) and route OpenCode + Hermes through subscription-backed Claude/Codex/Gemini accounts |
+| `CLI_PROXY_API_KEY` | `holycode-local` | Shared API key used by CLI Proxy clients (OpenCode, Hermes) |
+| `CLI_PROXY_AUTOWIRE` | (none) | `all` to auto-wire every facet, or comma-list of `opencode-anthropic`, `opencode-openai`, `opencode-google`, `hermes`. `false`/`none` reverts wiring. |
+| `CLI_PROXY_HERMES_PROVIDER` | `anthropic` | Protocol Hermes uses to talk to the proxy: `anthropic`, `openai`, or `google` |
 | `HOLYCODE_PLUGIN_UPDATE` | `manual` | Plugin update mode: `manual` (install if missing) or `auto` (install and update on boot) |
 
 > Plugin toggles (`ENABLE_CLAUDE_AUTH`, `ENABLE_OH_MY_OPENAGENT`) take effect on container restart. Set the env var and run `docker compose down && up -d`.
@@ -395,6 +399,8 @@ services:
 > `ENABLE_HERMES=true` starts Hermes on port `8642` inside the container. Hermes persists under `~/.hermes`, uses the already-installed `opencode` binary, and can expose an OpenAI-compatible API while delegating code work back into HolyCode.
 
 > Hermes is an API service, not a landing page. A `404` at `http://localhost:8642/` is expected. The important signal is that the port is listening and the process stays healthy.
+
+> `ENABLE_CLI_PROXY=true` starts the bundled CLI Proxy API on port `8317`. Combined with `CLI_PROXY_AUTOWIRE=all`, it transparently routes OpenCode and Hermes calls through subscription-backed Claude, Codex, and Gemini accounts (no API keys). OAuth flows have provider-specific callback ports — see the [CLI Proxy API](#cli-proxy-api) section and `/cli-proxy-api-setup` skill for the supported setup walkthrough.
 
 > `GIT_USER_NAME` and `GIT_USER_EMAIL` are only applied on first boot. To re-apply, delete the sentinel file and restart: `docker exec holycode rm /home/opencode/.config/opencode/.holycode-bootstrapped` then `docker compose restart`.
 
@@ -506,10 +512,11 @@ s6-overlay supervises OpenCode and Xvfb. If a process crashes, it restarts autom
 
 ## 🧩 Bundled Services
 
-HolyCode now ships with two optional layers on top of OpenCode. You do **not** need them to use the container. But if plain OpenCode gives you the hands, these two give you a brain and a control room.
+HolyCode ships with three optional layers on top of OpenCode. You do **not** need them to use the container, but each of them changes what HolyCode is for.
 
 - **Hermes Agent** is for when you want a smarter coordinator sitting above OpenCode.
 - **Paperclip** is for when you want a board, a workflow, and actual agent management instead of just one-off prompts.
+- **CLI Proxy API** is for when you want OpenCode and Hermes to talk to your Claude / Codex / Gemini **subscription** accounts via OAuth, without exposing API keys.
 
 Flip the env var, restart the container, and the service comes up alongside the normal web UI.
 
@@ -560,6 +567,54 @@ environment:
 
 Paperclip state lives under `/home/opencode/.paperclip`. HolyCode bootstraps it in `authenticated` mode so Docker port publishing works cleanly. Open the dashboard, set up your company, and hire OpenCode-backed employees from there.
 
+### CLI Proxy API
+
+CLI Proxy API is the credentials layer. It runs inside the container on port `8317`, exposes OpenAI-, Anthropic-, and Gemini-compatible endpoints, and lets you sign in to Claude, Codex, Gemini and Antigravity with your **subscription accounts** via OAuth — no raw API keys required. OpenCode (and Paperclip workers, since they spawn OpenCode) and Hermes can be auto-wired through it so every model call rides on those credentials.
+
+Why that matters:
+
+- **Subscription-backed model access.** Sign in once with your existing Claude / Codex / Gemini plan. Tokens persist under `~/.cli-proxy-api/` and the proxy refreshes them automatically.
+- **One key, three protocols.** The proxy accepts Anthropic `x-api-key`, OpenAI `Authorization: Bearer`, and Google `X-Goog-Api-Key` against the same allowlist, so a single shared `CLI_PROXY_API_KEY` covers all three OpenCode provider blocks.
+- **Pool credentials.** Add multiple accounts and let the proxy round-robin or stick to one until quota is hit. Fall back to API keys for providers without a subscription path (OpenRouter, DeepSeek, etc.).
+- **Auto-wire is reversible.** A managed-state sentinel tracks exactly which keys we set. Toggling `CLI_PROXY_AUTOWIRE=false` reverts cleanly without trampling your edits.
+
+Turn it on with:
+
+```yaml
+environment:
+  - ENABLE_CLI_PROXY=true
+  - CLI_PROXY_AUTOWIRE=all
+  # - CLI_PROXY_API_KEY=holycode-local
+  # - CLI_PROXY_HERMES_PROVIDER=anthropic
+```
+
+Then publish `8317:8317` for the API plus the OAuth callback port for whichever providers you log into:
+
+| Provider     | Callback port | Notes                                                  |
+| ------------ | ------------- | ------------------------------------------------------ |
+| Claude       | `54545`       | `cli-proxy-api -claude-login -no-browser`              |
+| Codex        | `1455`        | OR use `-codex-device-login` (no port required)        |
+| Gemini       | `8085`        | `cli-proxy-api -login -no-browser`                     |
+| Antigravity  | `51121`       | `cli-proxy-api -antigravity-login -no-browser`         |
+
+Run the matching login command from the host, e.g.:
+
+```bash
+docker exec -it holycode cli-proxy-api -codex-device-login
+```
+
+Then verify:
+
+```bash
+curl -s http://localhost:8317/v1/models -H "x-api-key: holycode-local" | head
+```
+
+The full setup walkthrough lives in the bundled `/cli-proxy-api-setup` skill — invoke it from inside OpenCode for an interactive flow tailored to your provider mix.
+
+CLI Proxy state lives under `/home/opencode/.cli-proxy-api`. The config file (`config.yaml`) hot-reloads on save, so most changes take effect within ~1 second.
+
+> **Sidecar mode:** if you'd rather run CLIProxyAPI standalone, the upstream image (`eceasy/cli-proxy-api:v6.10.1`) works fine — just point OpenCode at it manually. The bundled, auto-wired path documented above is the supported workflow.
+
 <p align="right">
   <a href="#top">back to top</a>
 </p>
@@ -581,6 +636,7 @@ graph TD
     G --> I[opencode web :4096]
     G --> Q[Hermes API :8642]
     G --> R[Paperclip UI :3100]
+    G --> S[CLI Proxy API :8317]
     I --> J[Web UI]
     J --> K[Your Browser]
     I --> L[CLI Access]
@@ -668,6 +724,38 @@ docker exec -it holycode bash -c "bunx oh-my-opencode refresh-model-capabilities
 
 HolyCode can guide the supported refresh path, but upstream OpenCode and oh-my-openagent model-resolution behavior still controls the final visible model state.
 
+### CLI Proxy API setup
+
+If you enabled `ENABLE_CLI_PROXY=true`, the `/cli-proxy-api-setup` skill walks you through:
+
+```text
+/cli-proxy-api-setup
+```
+
+That flow is the supported path for:
+
+- choosing which providers (Claude, Codex, Gemini, Antigravity) to log into
+- publishing the right OAuth callback ports in compose
+- running the right login command per provider
+- deciding which surfaces to auto-wire (`opencode-anthropic`, `opencode-openai`, `opencode-google`, `hermes`)
+- verifying the proxy is serving model lists and chat traffic
+
+Common follow-up commands:
+
+```bash
+# Codex device-flow login (no callback port required)
+docker exec -it holycode cli-proxy-api -codex-device-login
+
+# Claude OAuth (requires -p 54545:54545 in compose)
+docker exec -it holycode cli-proxy-api -claude-login -no-browser
+
+# Verify the proxy is up
+curl -s http://localhost:8317/v1/models -H "x-api-key: holycode-local" | head
+
+# Inspect or edit the proxy config (hot-reloads on save)
+$EDITOR ./data/opencode/.cli-proxy-api/config.yaml
+```
+
 ### Useful commands
 
 | Command | What it does |
@@ -681,6 +769,10 @@ HolyCode can guide the supported refresh path, but upstream OpenCode and oh-my-o
 | `opencode providers login` | Add or switch provider |
 | `bunx oh-my-opencode doctor` | Diagnose oh-my-openagent config and model resolution |
 | `bunx oh-my-opencode refresh-model-capabilities` | Refresh provider/model capability cache after provider changes |
+| `cli-proxy-api -claude-login -no-browser` | Log in to Claude subscription via the proxy (needs `-p 54545:54545`) |
+| `cli-proxy-api -codex-device-login` | Log in to Codex via device-code flow (no callback port required) |
+| `cli-proxy-api -login -no-browser` | Log in to Gemini via the proxy (needs `-p 8085:8085`) |
+| `curl http://localhost:8317/v1/models -H "x-api-key: holycode-local"` | Verify CLI Proxy is serving model lists |
 | `opencode models` | List available models |
 | `opencode models <provider>` | List models for a specific provider |
 | `opencode stats` | Show token usage and costs |

--- a/config/cli-proxy-api/config.example.yaml
+++ b/config/cli-proxy-api/config.example.yaml
@@ -7,7 +7,17 @@
 # Full reference (every option): https://github.com/router-for-me/CLIProxyAPI
 # ==============================================================================
 
-host: ""           # Bind all interfaces inside the container
+# Bind all interfaces inside the container so Docker port publishing
+# (-p 8317:8317) and OAuth callback flows work from the host browser.
+# Set to "127.0.0.1" only if you do NOT publish ports and only call the
+# proxy from OpenCode/Hermes inside the same container.
+#
+# SECURITY: when publishing port 8317, the proxy is reachable from any
+# network interface on the host. The default `api-keys` value below
+# (holycode-local) is shipped publicly in the HolyCode repo. Change
+# CLI_PROXY_API_KEY (.env) to a private value before exposing this port
+# anywhere beyond your own machine.
+host: ""
 port: 8317
 
 # Where OAuth tokens are stored. Resolves to /home/opencode/.cli-proxy-api/

--- a/config/cli-proxy-api/config.example.yaml
+++ b/config/cli-proxy-api/config.example.yaml
@@ -1,0 +1,65 @@
+# ==============================================================================
+# CLIProxyAPI - HolyCode default config
+#
+# Edit this file at: ./data/opencode/.cli-proxy-api/config.yaml on the host.
+# CLIProxyAPI hot-reloads on save, so most changes take effect within ~1 second.
+#
+# Full reference (every option): https://github.com/router-for-me/CLIProxyAPI
+# ==============================================================================
+
+host: ""           # Bind all interfaces inside the container
+port: 8317
+
+# Where OAuth tokens are stored. Resolves to /home/opencode/.cli-proxy-api/
+# inside the container == ./data/opencode/.cli-proxy-api/ on the host.
+auth-dir: "~/.cli-proxy-api"
+
+# Client-facing API keys. Anything that calls the proxy must present one of
+# these via Authorization, x-api-key, or X-Goog-Api-Key headers.
+# Override at container start by setting CLI_PROXY_API_KEY in your .env.
+api-keys:
+  - "holycode-local"
+
+debug: false
+usage-statistics-enabled: false
+
+remote-management:
+  allow-remote: false   # localhost-only management endpoints
+  secret-key: ""        # leave empty to fully disable /v0/management
+  disable-control-panel: false
+
+# Routing strategy for selecting credentials when multiple match.
+routing:
+  strategy: "round-robin"
+  session-affinity: false
+
+# OAuth-backed providers (Claude / Codex / Gemini / Antigravity / Kimi):
+# run the matching login command and CLIProxyAPI auto-discovers tokens
+# under auth-dir. No config block needed here.
+#
+# Examples:
+#   docker exec -it holycode cli-proxy-api -claude-login -no-browser
+#   docker exec -it holycode cli-proxy-api -codex-device-login
+#   docker exec -it holycode cli-proxy-api -login                   # Gemini
+
+# ------------------------------------------------------------------------------
+# Direct API-key providers (uncomment and fill what you need):
+# ------------------------------------------------------------------------------
+
+# claude-api-key:
+#   - api-key: "sk-ant-..."
+
+# gemini-api-key:
+#   - api-key: "AIza..."
+
+# codex-api-key:
+#   - api-key: "sk-..."
+
+# openai-compatibility:
+#   - name: "openrouter"
+#     base-url: "https://openrouter.ai/api/v1"
+#     api-key-entries:
+#       - api-key: "sk-or-v1-..."
+#     models:
+#       - name: "moonshotai/kimi-k2:free"
+#         alias: "kimi-k2"

--- a/config/hermes/config.example.yaml
+++ b/config/hermes/config.example.yaml
@@ -1,0 +1,32 @@
+# ==============================================================================
+# Hermes - HolyCode auto-wired config seed
+#
+# Seeded into ~/.hermes/config.yaml on first boot when:
+#   ENABLE_HERMES=true   AND   CLI_PROXY_AUTOWIRE includes "hermes" (or "all")
+#
+# After seeding, entrypoint.sh keeps the {model, auxiliary.*} blocks in sync
+# with CLI_PROXY_HERMES_PROVIDER on every container restart. Other sections
+# you add here are preserved.
+#
+# The ${CLI_PROXY_API_KEY} placeholder is expanded by Hermes at config-load
+# time using the value exported by entrypoint.sh.
+# ==============================================================================
+
+model:
+  provider: "anthropic"
+  base_url: "http://localhost:8317"
+  api_key: "${CLI_PROXY_API_KEY}"
+
+auxiliary:
+  vision:
+    provider: "auto"
+    base_url: "http://localhost:8317"
+    api_key: "${CLI_PROXY_API_KEY}"
+  web_extract:
+    provider: "auto"
+    base_url: "http://localhost:8317"
+    api_key: "${CLI_PROXY_API_KEY}"
+  compression:
+    provider: "auto"
+    base_url: "http://localhost:8317"
+    api_key: "${CLI_PROXY_API_KEY}"

--- a/config/skills/cli-proxy-api-setup/SKILL.md
+++ b/config/skills/cli-proxy-api-setup/SKILL.md
@@ -88,7 +88,6 @@ For each chosen provider, run inside the container:
 | Codex (oauth)| `docker exec -it holycode cli-proxy-api -codex-login -no-browser`                                  |
 | Gemini       | `docker exec -it holycode cli-proxy-api -login -no-browser`                                        |
 | Antigravity  | `docker exec -it holycode cli-proxy-api -antigravity-login -no-browser`                            |
-| Kimi         | `docker exec -it holycode cli-proxy-api -kimi-login -no-browser`                                   |
 
 The command prints a URL. Walk the user through:
 
@@ -168,6 +167,8 @@ Show the resulting diffs:
 - **Add model aliases:** add a `models:` list under any provider block and reference the alias from OpenCode.
 - **Inspect proxy logs:** `docker logs holycode 2>&1 | grep -i cli-proxy`.
 - **Disable auto-wire without losing your edits:** the `_holycode_cli_proxy_managed` sentinel makes off-toggling clean — entrypoint only reverts keys it set.
+- **Changing `CLI_PROXY_API_KEY` after first boot:** does **not** automatically rewrite `~/.cli-proxy-api/config.yaml`'s `api-keys:` list. OpenCode and Hermes will start using the new key and get 401s from the proxy. Edit `config.yaml` to add or replace the key (proxy hot-reloads).
+- **Security warning before publishing port 8317:** if `CLI_PROXY_API_KEY` is the default `holycode-local` (which is committed to the public repo), anyone with network reach to the host can use your subscription tokens. Always change it before exposing the port.
 
 ---
 
@@ -175,6 +176,7 @@ Show the resulting diffs:
 
 - Do not invent provider names that are not supported by the upstream binary.
 - Do not store API keys in `opencode.json` directly — always use `{env:CLI_PROXY_API_KEY}` substitution.
-- If the user has hand-edited `opencode.json` and the `_holycode_cli_proxy_managed` sentinel is missing, do not silently overwrite their `provider.*.options.baseURL` — explain the conflict and ask first.
+- The auto-wire entrypoint already skips providers/Hermes when it detects user-managed values without a sentinel — surface those skip warnings to the user and explain how to resolve (either remove the conflicting value, or accept they want to manage it themselves).
 - Always remind the user about the TOS disclaimer before they run their first OAuth login.
+- Always warn about port-publishing security before they uncomment `8317:8317` if `CLI_PROXY_API_KEY` is still `holycode-local`.
 - Keep responses short. Show the exact command, not a paragraph about it.

--- a/config/skills/cli-proxy-api-setup/SKILL.md
+++ b/config/skills/cli-proxy-api-setup/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: cli-proxy-api-setup
+description: Configure the CLI Proxy API bundled service in HolyCode. Walks the user through choosing providers, exposing OAuth callback ports, running the right login command, verifying the proxy, and (optionally) auto-wiring OpenCode and Hermes to route through it.
+---
+
+# cli-proxy-api-setup
+
+Use this skill when the user wants to:
+
+- set up CLI Proxy API for the first time inside HolyCode
+- log in to a new subscription provider (Claude, Codex, Gemini, Antigravity)
+- toggle whether OpenCode and/or Hermes route through the proxy
+- troubleshoot why a model call is not hitting the proxy
+
+CLI Proxy API lets the user sign into Claude, Codex, Gemini and Antigravity with their **subscription accounts** and use those accounts through OpenCode (and Hermes / Paperclip workers) without exposing API keys. Tokens stay on disk under `./data/opencode/.cli-proxy-api/`.
+
+> **Honest disclaimer:** Using subscription accounts via this proxy may violate the AI provider's terms of service depending on plan tier. Same caveat as `ENABLE_CLAUDE_AUTH`. Use at your own risk.
+
+---
+
+## Step 0 — Confirm the working context
+
+1. Verify you are inside a HolyCode container or a HolyCode-backed environment.
+2. Default paths used by this skill:
+   - Proxy config: `~/.cli-proxy-api/config.yaml` (= `./data/opencode/.cli-proxy-api/config.yaml` on the host)
+   - OpenCode config: `~/.config/opencode/opencode.json`
+   - Hermes config: `~/.hermes/config.yaml`
+3. If the proxy binary is not present (`command -v cli-proxy-api`), the user is on an older HolyCode image. Ask them to upgrade to the version bundling CLI Proxy API and stop.
+
+---
+
+## Step 1 — Detect current state
+
+Before asking questions, summarize what is already configured:
+
+1. Is `ENABLE_CLI_PROXY=true` in the running container? (`echo $ENABLE_CLI_PROXY`)
+2. Does `~/.cli-proxy-api/config.yaml` exist?
+3. Which OAuth tokens are already present? List files under `~/.cli-proxy-api/` excluding `config.yaml`.
+4. Is `CLI_PROXY_AUTOWIRE` set, and to what value?
+5. If `ENABLE_HERMES=true`, does `~/.hermes/config.yaml` show `model.base_url: http://localhost:8317`?
+
+State the summary in 3-5 lines. If nothing is configured yet, this is **first-time setup**. Otherwise this run is **reconfiguration**.
+
+---
+
+## Step 2 — Ask which providers the user wants
+
+Present the choices and let the user pick one or more:
+
+1. **Claude** (Anthropic subscription) — needs OAuth callback port `54545` published.
+2. **Codex** (OpenAI subscription via Codex CLI) — two options:
+   - **Device-code flow** (recommended): no port needed.
+   - **OAuth flow**: needs port `1455` published.
+3. **Gemini** (Google AI subscription) — needs port `8085`.
+4. **Antigravity** — needs port `51121`.
+5. **Direct API keys only** (Claude / Gemini / Codex / OpenRouter / etc., pooled via the proxy).
+
+If the user picks an OAuth provider, list exactly the host ports they need to expose in `docker-compose.yaml` and the published port for the proxy itself (`8317`).
+
+---
+
+## Step 3 — Verify compose configuration matches the chosen providers
+
+Inspect (or ask the user to inspect) their `docker-compose.yaml`. Confirm:
+
+1. `ENABLE_CLI_PROXY=true` is set in the `environment:` section.
+2. `8317:8317` is in `ports:`.
+3. The OAuth callback port for each chosen provider is in `ports:` (uncomment as needed).
+
+If any line is missing, give them the exact diff to apply, then run:
+
+```bash
+docker compose down && docker compose up -d
+```
+
+Wait for the container to be healthy before continuing.
+
+---
+
+## Step 4 — Run the login command(s)
+
+For each chosen provider, run inside the container:
+
+| Provider     | Command (from host)                                                                                |
+| ------------ | -------------------------------------------------------------------------------------------------- |
+| Claude       | `docker exec -it holycode cli-proxy-api -claude-login -no-browser`                                 |
+| Codex (dev)  | `docker exec -it holycode cli-proxy-api -codex-device-login`                                       |
+| Codex (oauth)| `docker exec -it holycode cli-proxy-api -codex-login -no-browser`                                  |
+| Gemini       | `docker exec -it holycode cli-proxy-api -login -no-browser`                                        |
+| Antigravity  | `docker exec -it holycode cli-proxy-api -antigravity-login -no-browser`                            |
+| Kimi         | `docker exec -it holycode cli-proxy-api -kimi-login -no-browser`                                   |
+
+The command prints a URL. Walk the user through:
+
+1. Copy the URL to their host browser.
+2. Complete provider auth.
+3. The browser is redirected to `http://localhost:<callback-port>/...`. Because the matching port is published in compose, the redirect lands inside the container and the login completes.
+4. The terminal prints "Login successful" or similar. If it hangs, the most common cause is an unpublished callback port — re-check Step 3.
+
+After success, a JSON token file appears under `~/.cli-proxy-api/`. List the directory to confirm.
+
+---
+
+## Step 5 — Verify the proxy is serving
+
+From the host:
+
+```bash
+curl -s http://localhost:8317/v1/models -H "x-api-key: holycode-local" | head -40
+```
+
+The response should be a JSON object with a `data` array of models. If it returns `401`, the API key in `~/.cli-proxy-api/config.yaml` does not match `holycode-local` — either edit the config or use the right key.
+
+Also try a Claude-protocol call to confirm the proxy is bridging protocols:
+
+```bash
+curl -s http://localhost:8317/v1/messages \
+  -H "x-api-key: holycode-local" \
+  -H "anthropic-version: 2023-06-01" \
+  -H "content-type: application/json" \
+  -d '{"model":"claude-sonnet-4-5-20250929","max_tokens":50,"messages":[{"role":"user","content":"hi"}]}' | head -20
+```
+
+If Claude OAuth was completed, this should return a real response.
+
+---
+
+## Step 6 — Auto-wire decision
+
+Ask the user which surfaces should automatically route through the proxy:
+
+| Surface                           | Effect                                                                       |
+| --------------------------------- | ---------------------------------------------------------------------------- |
+| OpenCode (Anthropic provider)     | OpenCode's anthropic-protocol calls go to the proxy at `localhost:8317`     |
+| OpenCode (OpenAI provider)        | OpenCode's openai-protocol calls go to the proxy at `localhost:8317/v1`     |
+| OpenCode (Google provider)        | OpenCode's google-protocol calls go to the proxy at `localhost:8317/v1beta` |
+| Hermes                            | Hermes `model.*` and `auxiliary.*` route through the proxy                  |
+
+Then set `CLI_PROXY_AUTOWIRE` accordingly:
+
+- `all` — wire everything (default). When `ENABLE_HERMES=true`, this includes Hermes.
+- Comma-list of `opencode-anthropic`, `opencode-openai`, `opencode-google`, `hermes` — wire only the chosen surfaces.
+- `false` or `none` — no auto-wire (the user manages `opencode.json` / `~/.hermes/config.yaml` themselves).
+
+If wiring Hermes, ask which protocol it should speak to the proxy (default `anthropic`):
+
+```bash
+CLI_PROXY_HERMES_PROVIDER=anthropic   # or openai, google
+```
+
+After updating `.env` or `docker-compose.yaml`, run:
+
+```bash
+docker compose down && docker compose up -d
+```
+
+Show the resulting diffs:
+
+- `~/.config/opencode/opencode.json` — should now contain `provider.<name>.options.baseURL` and `apiKey: "{env:CLI_PROXY_API_KEY}"` for each wired provider, plus a `_holycode_cli_proxy_managed` sentinel.
+- `~/.hermes/config.yaml` (only if Hermes wired) — should contain `model.base_url: http://localhost:8317` and matching `auxiliary.*`.
+
+---
+
+## Step 7 — Power-user pointers
+
+- **Edit proxy config:** `./data/opencode/.cli-proxy-api/config.yaml`. Hot-reloads on save.
+- **Pool more API keys:** uncomment and fill the `claude-api-key`, `gemini-api-key`, `codex-api-key`, or `openai-compatibility` blocks in the proxy config.
+- **Add model aliases:** add a `models:` list under any provider block and reference the alias from OpenCode.
+- **Inspect proxy logs:** `docker logs holycode 2>&1 | grep -i cli-proxy`.
+- **Disable auto-wire without losing your edits:** the `_holycode_cli_proxy_managed` sentinel makes off-toggling clean — entrypoint only reverts keys it set.
+
+---
+
+## Rules
+
+- Do not invent provider names that are not supported by the upstream binary.
+- Do not store API keys in `opencode.json` directly — always use `{env:CLI_PROXY_API_KEY}` substitution.
+- If the user has hand-edited `opencode.json` and the `_holycode_cli_proxy_managed` sentinel is missing, do not silently overwrite their `provider.*.options.baseURL` — explain the conflict and ask first.
+- Always remind the user about the TOS disclaimer before they run their first OAuth login.
+- Keep responses short. Show the exact command, not a paragraph about it.

--- a/docker-compose.full.yaml
+++ b/docker-compose.full.yaml
@@ -13,6 +13,15 @@ services:
       - "4096:4096" # OpenCode web UI
       # - "3100:3100" # Paperclip dashboard
       # - "8642:8642" # Hermes API server
+      # --- CLI Proxy API + OAuth callback ports (uncomment what you need) ---
+      # The proxy accepts requests on 8317. OAuth providers redirect the user's
+      # host browser to provider-specific callback ports — publish only the
+      # callback ports for the providers you actually log into.
+      # - "8317:8317"   # CLI Proxy API (OpenAI/Anthropic/Gemini-compatible)
+      # - "54545:54545" # CLI Proxy: Claude OAuth callback
+      # - "1455:1455"   # CLI Proxy: Codex OAuth callback (skip if using -codex-device-login)
+      # - "8085:8085"   # CLI Proxy: Gemini OAuth callback
+      # - "51121:51121" # CLI Proxy: Antigravity OAuth callback
 
     volumes:
       # --- Persistent state (all OpenCode data under home dir) ---
@@ -90,3 +99,21 @@ services:
       # Hermes starts an OpenAI-compatible API + messaging-capable meta-agent
       # - ENABLE_HERMES=true
       # - HERMES_PORT=8642
+
+      # --- CLI Proxy API ---
+      # Routes OpenCode (and Paperclip workers, and optionally Hermes) through
+      # subscription-backed Claude/Codex/Gemini accounts via OAuth, instead of
+      # exposing API keys. Tokens persist under ./data/opencode/.cli-proxy-api/.
+      # See /cli-proxy-api-setup skill or README for the full setup walkthrough.
+      # - ENABLE_CLI_PROXY=true
+      # - CLI_PROXY_API_KEY=holycode-local
+      # CLI_PROXY_AUTOWIRE selects which surfaces auto-route through the proxy:
+      #   all                                  # everything (Hermes only when ENABLE_HERMES=true)
+      #   opencode-anthropic,opencode-openai   # comma-list, fine-grained
+      #   hermes                               # only Hermes
+      #   false / none / unset                 # no auto-wire (you manage configs yourself)
+      # - CLI_PROXY_AUTOWIRE=all
+      # CLI_PROXY_HERMES_PROVIDER controls which protocol Hermes uses to talk
+      # to the proxy. Pick the protocol that matches the upstream OAuth account
+      # most likely to serve your Hermes prompts.
+      # - CLI_PROXY_HERMES_PROVIDER=anthropic   # anthropic | openai | google

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,8 +10,13 @@ services:
     shm_size: 2g
     ports:
       - "4096:4096"
-      # - "3100:3100"   # Paperclip dashboard
-      # - "8642:8642"   # Hermes API server
+      # - "3100:3100"    # Paperclip dashboard
+      # - "8642:8642"    # Hermes API server
+      # - "8317:8317"    # CLI Proxy API (OpenAI/Anthropic/Gemini-compatible)
+      # - "54545:54545"  # CLI Proxy: Claude OAuth callback
+      # - "1455:1455"    # CLI Proxy: Codex OAuth callback (skip if using -codex-device-login)
+      # - "8085:8085"    # CLI Proxy: Gemini OAuth callback
+      # - "51121:51121"  # CLI Proxy: Antigravity OAuth callback
     volumes:
       - ./data/opencode:/home/opencode
       - ./local-cache/opencode:/home/opencode/.cache/opencode
@@ -25,3 +30,8 @@ services:
       # - PAPERCLIP_DEPLOYMENT_MODE=authenticated
       # - ENABLE_HERMES=true
       # - HERMES_PORT=8642
+      # --- CLI Proxy API ---
+      # - ENABLE_CLI_PROXY=true
+      # - CLI_PROXY_AUTOWIRE=all                  # all | comma-list of opencode-anthropic, opencode-openai, opencode-google, hermes | false
+      # - CLI_PROXY_API_KEY=holycode-local
+      # - CLI_PROXY_HERMES_PROVIDER=anthropic     # anthropic | openai | google -- which protocol Hermes speaks to the proxy

--- a/s6-overlay/s6-rc.d/cli-proxy-api/run
+++ b/s6-overlay/s6-rc.d/cli-proxy-api/run
@@ -1,0 +1,17 @@
+#!/command/with-contenv sh
+set -e
+
+CLI_PROXY_HOME="${CLI_PROXY_HOME:-/home/opencode/.cli-proxy-api}"
+config_file="$CLI_PROXY_HOME/config.yaml"
+
+if [ ! -f "$config_file" ]; then
+  echo "[cli-proxy-api] config.yaml missing at $config_file; seeding default"
+  mkdir -p "$CLI_PROXY_HOME"
+  install -m 0644 -o opencode -g opencode \
+    /usr/local/share/holycode/cli-proxy-api/config.example.yaml \
+    "$config_file"
+fi
+
+exec s6-setuidgid opencode env \
+  HOME="/home/opencode" \
+  cli-proxy-api --config "$config_file"

--- a/s6-overlay/s6-rc.d/cli-proxy-api/type
+++ b/s6-overlay/s6-rc.d/cli-proxy-api/type
@@ -1,0 +1,1 @@
+longrun

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -56,8 +56,9 @@ CLI_PROXY_CONFIG="$CLI_PROXY_DIR/config.yaml"
 mkdir -p "$CLI_PROXY_DIR"
 if [ ! -f "$CLI_PROXY_CONFIG" ]; then
     cp "$SOURCE_DIR/cli-proxy-api/config.example.yaml" "$CLI_PROXY_CONFIG"
+    # Mutate as root (cp wrote as root) — chown happens below for both files.
     if [ -n "${CLI_PROXY_API_KEY}" ] && [ "${CLI_PROXY_API_KEY}" != "holycode-local" ]; then
-        runuser -u "$OC_USER" -- python3 - "$CLI_PROXY_CONFIG" "$CLI_PROXY_API_KEY" <<'PY'
+        python3 - "$CLI_PROXY_CONFIG" "$CLI_PROXY_API_KEY" <<'PY' || echo "[bootstrap] WARNING: failed to inject CLI_PROXY_API_KEY into config.yaml"
 import sys
 import yaml
 config_file, api_key = sys.argv[1], sys.argv[2]

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -48,6 +48,32 @@ else
     echo "[bootstrap] opencode.json already exists, skipping"
 fi
 
+# ---------- Seed CLIProxyAPI config ----------
+# Always seeded (even when ENABLE_CLI_PROXY=false) so that toggling on later
+# does not require a re-bootstrap. Cheap (~50 lines of YAML).
+CLI_PROXY_DIR="$OC_HOME/.cli-proxy-api"
+CLI_PROXY_CONFIG="$CLI_PROXY_DIR/config.yaml"
+mkdir -p "$CLI_PROXY_DIR"
+if [ ! -f "$CLI_PROXY_CONFIG" ]; then
+    cp "$SOURCE_DIR/cli-proxy-api/config.example.yaml" "$CLI_PROXY_CONFIG"
+    if [ -n "${CLI_PROXY_API_KEY}" ] && [ "${CLI_PROXY_API_KEY}" != "holycode-local" ]; then
+        runuser -u "$OC_USER" -- python3 - "$CLI_PROXY_CONFIG" "$CLI_PROXY_API_KEY" <<'PY'
+import sys
+import yaml
+config_file, api_key = sys.argv[1], sys.argv[2]
+with open(config_file, "r", encoding="utf-8") as f:
+    cfg = yaml.safe_load(f) or {}
+cfg["api-keys"] = [api_key]
+with open(config_file, "w", encoding="utf-8") as f:
+    yaml.safe_dump(cfg, f, sort_keys=False)
+PY
+    fi
+    echo "[bootstrap] Seeded CLIProxyAPI config at $CLI_PROXY_CONFIG"
+else
+    echo "[bootstrap] CLIProxyAPI config.yaml already exists, skipping"
+fi
+chown -R "$PUID:$PGID" "$CLI_PROXY_DIR"
+
 sync_shipped_skills
 
 # ---------- Git configuration ----------

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -305,12 +305,12 @@ PY
 
     # CLI Proxy auto-wire (OpenCode providers)
     CLI_PROXY_AUTOWIRE_SPEC="${CLI_PROXY_AUTOWIRE:-}"
-    OC_PROXY_MARKER="$OC_HOME/.config/opencode/.holycode-cli-proxy-managed.json"
+    OC_PROXY_MARKER="$OC_HOME/.config/opencode/.holycode-cli-proxy-managed"
     runuser -u "$OC_USER" -- python3 - \
         "$CONFIG_FILE" \
         "$OC_PROXY_MARKER" \
         "CLI_PROXY_API_KEY" \
-        "$CLI_PROXY_AUTOWIRE_SPEC" <<'PY'
+        "$CLI_PROXY_AUTOWIRE_SPEC" <<'PY' || echo "[entrypoint] WARNING: CLI Proxy auto-wire (OpenCode) failed; check $CONFIG_FILE for malformed JSON"
 import json
 import os
 import sys
@@ -328,11 +328,12 @@ legacy = {"anthropic": "opencode-anthropic", "openai": "opencode-openai", "googl
 
 if spec in ("", "false", "none"):
     requested = set()
-elif spec == "all":
-    requested = set(oc_targets)
 else:
     tokens = [t.strip().lower() for t in spec.split(",") if t.strip()]
-    requested = {legacy.get(t, t) for t in tokens}
+    if "all" in tokens:
+        requested = set(oc_targets) | {"hermes"}
+    else:
+        requested = {legacy.get(t, t) for t in tokens}
 
 to_wire = requested & oc_targets
 
@@ -370,26 +371,46 @@ for token in prev:
     if not p:
         cfg["provider"].pop(name, None)
 
-# Apply new wiring
+# Apply new wiring -- skip providers where the user has set a custom baseURL
+# or apiKey we did not write previously, to avoid clobbering hand-edited config.
+prev_set = set(prev)
+applied = []
+skipped = []
 for token in sorted(to_wire):
     name, base = mapping[token]
     p = cfg["provider"].setdefault(name, {})
     opts = p.setdefault("options", {})
+    existing_base = opts.get("baseURL")
+    existing_key = opts.get("apiKey")
+    user_managed = token not in prev_set and (
+        (existing_base is not None and existing_base != base)
+        or (existing_key is not None and existing_key != api_ref)
+    )
+    if user_managed:
+        skipped.append(name)
+        continue
     opts["baseURL"] = base
     opts["apiKey"] = api_ref
+    applied.append(token)
 
 with open(config_file, "w", encoding="utf-8") as f:
     json.dump(cfg, f, indent=2)
 
-if to_wire:
+if applied:
     os.makedirs(os.path.dirname(marker_file), exist_ok=True)
     with open(marker_file, "w", encoding="utf-8") as f:
-        json.dump({"providers": sorted(to_wire)}, f, indent=2)
-    print("[entrypoint] CLI Proxy auto-wire (OpenCode): " + ",".join(sorted(to_wire)))
+        json.dump({"providers": sorted(applied)}, f, indent=2)
+    print("[entrypoint] CLI Proxy auto-wire (OpenCode): " + ",".join(sorted(applied)))
 elif os.path.isfile(marker_file):
     os.remove(marker_file)
     if prev:
         print("[entrypoint] CLI Proxy auto-wire (OpenCode): reverted")
+if skipped:
+    print(
+        "[entrypoint] WARNING: CLI Proxy auto-wire skipped provider(s) "
+        + ",".join(sorted(skipped))
+        + " due to user-managed baseURL/apiKey in opencode.json"
+    )
 PY
 fi
 
@@ -404,7 +425,7 @@ if [ "${ENABLE_HERMES}" = "true" ]; then
         "$HERMES_TEMPLATE" \
         "CLI_PROXY_API_KEY" \
         "${CLI_PROXY_AUTOWIRE:-}" \
-        "$HERMES_PROVIDER" <<'PY'
+        "$HERMES_PROVIDER" <<'PY' || echo "[entrypoint] WARNING: CLI Proxy auto-wire (Hermes) failed; check $HERMES_CONFIG for malformed YAML"
 import os
 import sys
 
@@ -427,15 +448,17 @@ api_ref = "${" + api_env_var + "}"
 legacy = {"anthropic": "opencode-anthropic", "openai": "opencode-openai", "google": "opencode-google"}
 if spec in ("", "false", "none"):
     requested = set()
-elif spec == "all":
-    requested = {"opencode-anthropic", "opencode-openai", "opencode-google", "hermes"}
 else:
     tokens = [t.strip().lower() for t in spec.split(",") if t.strip()]
-    requested = {legacy.get(t, t) for t in tokens}
+    if "all" in tokens:
+        requested = {"opencode-anthropic", "opencode-openai", "opencode-google", "hermes"}
+    else:
+        requested = {legacy.get(t, t) for t in tokens}
 wire_hermes = "hermes" in requested
 
 if wire_hermes:
-    if not os.path.isfile(config_file):
+    file_existed = os.path.isfile(config_file)
+    if not file_existed:
         os.makedirs(os.path.dirname(config_file), exist_ok=True)
         with open(template_file, "r", encoding="utf-8") as src:
             with open(config_file, "w", encoding="utf-8") as dst:
@@ -444,26 +467,41 @@ if wire_hermes:
     with open(config_file, "r", encoding="utf-8") as f:
         cfg = yaml.safe_load(f) or {}
 
-    cfg.setdefault("model", {})
-    cfg["model"]["provider"] = provider
-    cfg["model"]["base_url"] = base_url
-    cfg["model"]["api_key"] = api_ref
+    sentinel_present = isinstance(cfg.get("_holycode_cli_proxy_managed"), dict)
+    existing_model = cfg.get("model") if isinstance(cfg.get("model"), dict) else {}
+    # Only treat as user-managed if the file was here before our run and lacks
+    # our sentinel. Template-seeded content is not user-managed.
+    user_managed_model = file_existed and (not sentinel_present) and any(
+        existing_model.get(k) is not None and existing_model.get(k) != v
+        for k, v in (("provider", provider), ("base_url", base_url), ("api_key", api_ref))
+    )
 
-    cfg.setdefault("auxiliary", {})
-    for aux in ("vision", "web_extract", "compression"):
-        cfg["auxiliary"].setdefault(aux, {})
-        cfg["auxiliary"][aux]["base_url"] = base_url
-        cfg["auxiliary"][aux]["api_key"] = api_ref
+    if user_managed_model:
+        print(
+            "[entrypoint] WARNING: CLI Proxy auto-wire (Hermes) skipped — "
+            "user-managed model.{provider,base_url,api_key} present without a managed sentinel"
+        )
+    else:
+        cfg.setdefault("model", {})
+        cfg["model"]["provider"] = provider
+        cfg["model"]["base_url"] = base_url
+        cfg["model"]["api_key"] = api_ref
 
-    cfg["_holycode_cli_proxy_managed"] = {
-        "applied_provider": provider,
-        "applied_base_url": base_url,
-        "applied_api_ref": api_ref,
-    }
+        cfg.setdefault("auxiliary", {})
+        for aux in ("vision", "web_extract", "compression"):
+            cfg["auxiliary"].setdefault(aux, {})
+            cfg["auxiliary"][aux]["base_url"] = base_url
+            cfg["auxiliary"][aux]["api_key"] = api_ref
 
-    with open(config_file, "w", encoding="utf-8") as f:
-        yaml.safe_dump(cfg, f, sort_keys=False)
-    print("[entrypoint] CLI Proxy auto-wire (Hermes): provider=" + provider)
+        cfg["_holycode_cli_proxy_managed"] = {
+            "applied_provider": provider,
+            "applied_base_url": base_url,
+            "applied_api_ref": api_ref,
+        }
+
+        with open(config_file, "w", encoding="utf-8") as f:
+            yaml.safe_dump(cfg, f, sort_keys=False)
+        print("[entrypoint] CLI Proxy auto-wire (Hermes): provider=" + provider)
 elif os.path.isfile(config_file):
     with open(config_file, "r", encoding="utf-8") as f:
         cfg = yaml.safe_load(f) or {}

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -195,6 +195,25 @@ else
     rm -f /etc/s6-overlay/s6-rc.d/user/contents.d/paperclip
 fi
 
+# Export proxy API key once for both OpenCode {env:...} and Hermes ${...} expansion.
+CLI_PROXY_API_KEY="${CLI_PROXY_API_KEY:-holycode-local}"
+export CLI_PROXY_API_KEY
+
+if [ "${ENABLE_CLI_PROXY}" = "true" ]; then
+    export CLI_PROXY_HOME="${CLI_PROXY_HOME:-$OC_HOME/.cli-proxy-api}"
+    mkdir -p "$CLI_PROXY_HOME"
+    chown "$PUID:$PGID" "$CLI_PROXY_HOME" 2>/dev/null || true
+    touch /etc/s6-overlay/s6-rc.d/user/contents.d/cli-proxy-api
+    mkdir -p /etc/s6-overlay/s6-rc.d/opencode/dependencies.d
+    touch /etc/s6-overlay/s6-rc.d/opencode/dependencies.d/cli-proxy-api
+else
+    rm -f /etc/s6-overlay/s6-rc.d/user/contents.d/cli-proxy-api
+    rm -f /etc/s6-overlay/s6-rc.d/opencode/dependencies.d/cli-proxy-api
+    # Auto-wire only makes sense when the proxy is running. Force revert if
+    # the user disabled the proxy but left CLI_PROXY_AUTOWIRE set.
+    CLI_PROXY_AUTOWIRE="false"
+fi
+
 # ---------- Plugin toggles (run every boot for enable/disable) ----------
 CONFIG_FILE="$OC_HOME/.config/opencode/opencode.json"
 if [ -f "$CONFIG_FILE" ]; then
@@ -283,6 +302,201 @@ with open(config_file, 'w', encoding='utf-8') as f:
 PY
         fi
     fi
+
+    # CLI Proxy auto-wire (OpenCode providers)
+    CLI_PROXY_AUTOWIRE_SPEC="${CLI_PROXY_AUTOWIRE:-}"
+    OC_PROXY_MARKER="$OC_HOME/.config/opencode/.holycode-cli-proxy-managed.json"
+    runuser -u "$OC_USER" -- python3 - \
+        "$CONFIG_FILE" \
+        "$OC_PROXY_MARKER" \
+        "CLI_PROXY_API_KEY" \
+        "$CLI_PROXY_AUTOWIRE_SPEC" <<'PY'
+import json
+import os
+import sys
+
+config_file, marker_file, api_env_var, spec = sys.argv[1:5]
+spec = (spec or "").strip().lower()
+
+oc_targets = {"opencode-anthropic", "opencode-openai", "opencode-google"}
+mapping = {
+    "opencode-anthropic": ("anthropic", "http://localhost:8317"),
+    "opencode-openai":    ("openai",    "http://localhost:8317/v1"),
+    "opencode-google":    ("google",    "http://localhost:8317/v1beta"),
+}
+legacy = {"anthropic": "opencode-anthropic", "openai": "opencode-openai", "google": "opencode-google"}
+
+if spec in ("", "false", "none"):
+    requested = set()
+elif spec == "all":
+    requested = set(oc_targets)
+else:
+    tokens = [t.strip().lower() for t in spec.split(",") if t.strip()]
+    requested = {legacy.get(t, t) for t in tokens}
+
+to_wire = requested & oc_targets
+
+with open(config_file, "r", encoding="utf-8") as f:
+    cfg = json.load(f)
+cfg.setdefault("provider", {})
+
+prev = []
+if os.path.isfile(marker_file):
+    try:
+        with open(marker_file, "r", encoding="utf-8") as f:
+            prev = json.load(f).get("providers", []) or []
+    except Exception:
+        prev = []
+
+api_ref = "{env:" + api_env_var + "}"
+
+# Revert previously-managed wiring (only when value still matches what we wrote)
+for token in prev:
+    if token not in mapping:
+        continue
+    name, base = mapping[token]
+    p = cfg["provider"].get(name)
+    if not isinstance(p, dict):
+        continue
+    opts = p.get("options")
+    if not isinstance(opts, dict):
+        continue
+    if opts.get("baseURL") == base:
+        opts.pop("baseURL", None)
+    if opts.get("apiKey") == api_ref:
+        opts.pop("apiKey", None)
+    if not opts:
+        p.pop("options", None)
+    if not p:
+        cfg["provider"].pop(name, None)
+
+# Apply new wiring
+for token in sorted(to_wire):
+    name, base = mapping[token]
+    p = cfg["provider"].setdefault(name, {})
+    opts = p.setdefault("options", {})
+    opts["baseURL"] = base
+    opts["apiKey"] = api_ref
+
+with open(config_file, "w", encoding="utf-8") as f:
+    json.dump(cfg, f, indent=2)
+
+if to_wire:
+    os.makedirs(os.path.dirname(marker_file), exist_ok=True)
+    with open(marker_file, "w", encoding="utf-8") as f:
+        json.dump({"providers": sorted(to_wire)}, f, indent=2)
+    print("[entrypoint] CLI Proxy auto-wire (OpenCode): " + ",".join(sorted(to_wire)))
+elif os.path.isfile(marker_file):
+    os.remove(marker_file)
+    if prev:
+        print("[entrypoint] CLI Proxy auto-wire (OpenCode): reverted")
+PY
+fi
+
+# ---------- Hermes auto-wire (only when Hermes is enabled) ----------
+if [ "${ENABLE_HERMES}" = "true" ]; then
+    HERMES_HOME="${HERMES_HOME:-$OC_HOME/.hermes}"
+    HERMES_CONFIG="$HERMES_HOME/config.yaml"
+    HERMES_TEMPLATE="/usr/local/share/holycode/hermes/config.example.yaml"
+    HERMES_PROVIDER="${CLI_PROXY_HERMES_PROVIDER:-anthropic}"
+    runuser -u "$OC_USER" -- python3 - \
+        "$HERMES_CONFIG" \
+        "$HERMES_TEMPLATE" \
+        "CLI_PROXY_API_KEY" \
+        "${CLI_PROXY_AUTOWIRE:-}" \
+        "$HERMES_PROVIDER" <<'PY'
+import os
+import sys
+
+import yaml
+
+config_file, template_file, api_env_var, spec, provider = sys.argv[1:6]
+spec = (spec or "").strip().lower()
+provider = (provider or "anthropic").strip().lower()
+
+provider_paths = {
+    "anthropic": "http://localhost:8317",
+    "openai":    "http://localhost:8317/v1",
+    "google":    "http://localhost:8317/v1beta",
+}
+if provider not in provider_paths:
+    provider = "anthropic"
+base_url = provider_paths[provider]
+api_ref = "${" + api_env_var + "}"
+
+legacy = {"anthropic": "opencode-anthropic", "openai": "opencode-openai", "google": "opencode-google"}
+if spec in ("", "false", "none"):
+    requested = set()
+elif spec == "all":
+    requested = {"opencode-anthropic", "opencode-openai", "opencode-google", "hermes"}
+else:
+    tokens = [t.strip().lower() for t in spec.split(",") if t.strip()]
+    requested = {legacy.get(t, t) for t in tokens}
+wire_hermes = "hermes" in requested
+
+if wire_hermes:
+    if not os.path.isfile(config_file):
+        os.makedirs(os.path.dirname(config_file), exist_ok=True)
+        with open(template_file, "r", encoding="utf-8") as src:
+            with open(config_file, "w", encoding="utf-8") as dst:
+                dst.write(src.read())
+
+    with open(config_file, "r", encoding="utf-8") as f:
+        cfg = yaml.safe_load(f) or {}
+
+    cfg.setdefault("model", {})
+    cfg["model"]["provider"] = provider
+    cfg["model"]["base_url"] = base_url
+    cfg["model"]["api_key"] = api_ref
+
+    cfg.setdefault("auxiliary", {})
+    for aux in ("vision", "web_extract", "compression"):
+        cfg["auxiliary"].setdefault(aux, {})
+        cfg["auxiliary"][aux]["base_url"] = base_url
+        cfg["auxiliary"][aux]["api_key"] = api_ref
+
+    cfg["_holycode_cli_proxy_managed"] = {
+        "applied_provider": provider,
+        "applied_base_url": base_url,
+        "applied_api_ref": api_ref,
+    }
+
+    with open(config_file, "w", encoding="utf-8") as f:
+        yaml.safe_dump(cfg, f, sort_keys=False)
+    print("[entrypoint] CLI Proxy auto-wire (Hermes): provider=" + provider)
+elif os.path.isfile(config_file):
+    with open(config_file, "r", encoding="utf-8") as f:
+        cfg = yaml.safe_load(f) or {}
+    sentinel = cfg.get("_holycode_cli_proxy_managed")
+    if isinstance(sentinel, dict):
+        prev_provider = sentinel.get("applied_provider", "anthropic")
+        prev_base = sentinel.get("applied_base_url", provider_paths.get(prev_provider, ""))
+        prev_api = sentinel.get("applied_api_ref", api_ref)
+
+        model = cfg.get("model")
+        if isinstance(model, dict):
+            if model.get("provider") == prev_provider:
+                model.pop("provider", None)
+            if model.get("base_url") == prev_base:
+                model.pop("base_url", None)
+            if model.get("api_key") == prev_api:
+                model.pop("api_key", None)
+
+        aux_root = cfg.get("auxiliary", {})
+        for aux in ("vision", "web_extract", "compression"):
+            aux_cfg = aux_root.get(aux)
+            if not isinstance(aux_cfg, dict):
+                continue
+            if aux_cfg.get("base_url") == prev_base:
+                aux_cfg.pop("base_url", None)
+            if aux_cfg.get("api_key") == prev_api:
+                aux_cfg.pop("api_key", None)
+
+        cfg.pop("_holycode_cli_proxy_managed", None)
+        with open(config_file, "w", encoding="utf-8") as f:
+            yaml.safe_dump(cfg, f, sort_keys=False)
+        print("[entrypoint] CLI Proxy auto-wire (Hermes): reverted")
+PY
 fi
 
 # ---------- Hand off to s6-overlay ----------


### PR DESCRIPTION
## Summary

- Adds **CLI Proxy API** ([eceasy/cli-proxy-api](https://github.com/router-for-me/CLIProxyAPI) `v6.10.1`, port `8317`) as a fourth optional bundled service alongside Hermes and Paperclip — supervised by s6-overlay, toggled with `ENABLE_CLI_PROXY=true`.
- Lets HolyCode users sign into **Claude / Codex / Gemini / Antigravity** with their **subscription accounts** via OAuth and route OpenCode (and Paperclip workers) and Hermes through those credentials — no API keys required.
- Auto-wire mutates `~/.config/opencode/opencode.json` (`provider.<name>.options.baseURL` + `apiKey`) and `~/.hermes/config.yaml` (`model.*` + `auxiliary.*`) and is reverted cleanly when toggled off via a managed-state sentinel. Disabling the proxy forces revert even if `CLI_PROXY_AUTOWIRE` is left set.
- New `/cli-proxy-api-setup` skill guides the user through provider selection, OAuth port publishing, the right login command, verification, and auto-wire.

## Why

OpenCode users on Claude Max / ChatGPT Plus / Gemini Advanced have no first-class way to use those subscriptions inside HolyCode without putting raw API keys (or session tokens) in env vars. CLIProxyAPI solves that by speaking the Anthropic, OpenAI, and Gemini protocols against OAuth tokens it manages itself. Bundling it as a toggleable service mirrors how Hermes and Paperclip are integrated, so users only learn one pattern.

## Configuration surface

| Var | Default | Purpose |
|---|---|---|
| `ENABLE_CLI_PROXY` | _(unset)_ | Start the proxy on `8317` |
| `CLI_PROXY_API_KEY` | `holycode-local` | Shared client key (Anthropic `x-api-key`, OpenAI `Authorization: Bearer`, Google `X-Goog-Api-Key`) |
| `CLI_PROXY_AUTOWIRE` | _(unset)_ | `all` or comma-list of `opencode-anthropic`, `opencode-openai`, `opencode-google`, `hermes`. `false`/`none` reverts. |
| `CLI_PROXY_HERMES_PROVIDER` | `anthropic` | Protocol Hermes uses to talk to the proxy (`anthropic`/`openai`/`google`) |

Compose adds five new commented ports: `8317` (API) plus `54545` / `1455` / `8085` / `51121` for Claude / Codex / Gemini / Antigravity OAuth callbacks. Codex device-flow login (`-codex-device-login`) needs no callback port.

## Architecture

- Multi-stage Docker COPY of the binary from `eceasy/cli-proxy-api:v6.10.1` (~50 MB)
- s6-overlay supervised service (`/etc/s6-overlay/s6-rc.d/cli-proxy-api/`)
- Conditional `dependencies.d/cli-proxy-api` on the opencode service when proxy is enabled — guarantees opencode waits for proxy startup
- Config seeded into `~/.cli-proxy-api/config.yaml` on first boot (hot-reloads on save)
- OAuth tokens persist via the existing `./data/opencode` bind mount

## Test plan

End-to-end verified locally on Apple Silicon:

- [x] `docker build` succeeds (image size +~50 MB)
- [x] Proxy disabled (default): cli-proxy-api absent from `s6-rc.d/user/contents.d/`, web UI on 4096 healthy, port 8317 not listening
- [x] Proxy enabled, no auto-wire: `/v1/models` returns 200, dependencies marker present, bootstrap seeded `config.yaml`
- [x] Auto-wire `all` + Hermes anthropic: `opencode.json` shows the three provider blocks with correct baseURLs and `{env:CLI_PROXY_API_KEY}` substitution; `~/.hermes/config.yaml` shows `model.*` + `auxiliary.*` with sentinel
- [x] Hermes provider switch (anthropic → openai → google): config picks up new base URLs cleanly
- [x] `CLI_PROXY_AUTOWIRE=false`: opencode.json + hermes config reverted, sentinels removed
- [x] `ENABLE_CLI_PROXY=false` with `CLI_PROXY_AUTOWIRE=all` left set: forces revert (proxy not running, no broken pointers left)
- [x] API key enforcement: 401 on wrong key, 200 on `x-api-key`, 200 on `Authorization: Bearer`
- [x] `with-contenv` propagates `CLI_PROXY_API_KEY` and friends to s6 services
- [x] `config.yaml` hot-reload (host edit → reload log line within 1s)
- [x] OAuth binary smoke test (`-h` works, login flags listed)

Not tested in this branch (requires live OAuth):

- [ ] End-to-end Claude / Codex / Gemini OAuth login completion
- [ ] Real chat traffic through `/v1/messages` with valid subscription tokens

## Out of scope

- TLS termination (use `tls.enable: true` in `config.yaml` if needed)
- Sidecar deployment (documented as one-line note — the upstream image works standalone if a user prefers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)